### PR TITLE
Fixed typo

### DIFF
--- a/class/Query.php
+++ b/class/Query.php
@@ -55,7 +55,7 @@
          * @return operation
          */
         public function getOperation () {
-            return $this->opertaion;
+            return $this->operation;
         }
     }
 ?>


### PR DESCRIPTION
Fixed a typo of a variable in the `Query` class